### PR TITLE
Fix docker run --cap-add SYS_NICE parameter

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -45,7 +45,7 @@ You can pull the `Merlin-Training` container by running the following command:
 DLRM model traning:
 
 ```
-docker run --gpus=all -it --cap-add SYS_NIC -v ${PWD}:/dlrm_train/ --net=host nvcr.io/nvidia/merlin/merlin-training:22.02 /bin/bash
+docker run --gpus=all -it --cap-add SYS_NICE -v ${PWD}:/dlrm_train/ --net=host nvcr.io/nvidia/merlin/merlin-training:22.02 /bin/bash
 ```
 
 Wide&Deep model training:


### PR DESCRIPTION
Hi,

There is a small typo in one of the docker run examples.

This PR fixes it.