### PR TITLE
docs: Fix link to HPS documentation

### DIFF
--- a/samples/hierarchical_deployment/README.md
+++ b/samples/hierarchical_deployment/README.md
@@ -1,7 +1,7 @@
 # HugeCTR Hierarchical Parameter Server for Inference Acceleration
 
 ## Overview
-HugeCTR Inference Hierarchical Parameter Server implemented a hierarchical storage mechanism between local SSDs and CPU memory, which breaks the convention that the embedding table must be stored in local CPU memory. The distributed Redis cluster is introduced as a CPU cache to store larger embedding tables and interact with the GPU embedding cache directly. The local RocksDB serves as a query engine to back up the complete embedding table on the local SSDs in order to assist the Redis cluster to perform missing embedding keys look up. For a detailed documentation of hugectr hierarchical parameter server, please refer to [this documentation](../../docs/hierarchical_parameter_server.md).
+HugeCTR Inference Hierarchical Parameter Server implemented a hierarchical storage mechanism between local SSDs and CPU memory, which breaks the convention that the embedding table must be stored in local CPU memory. The distributed Redis cluster is introduced as a CPU cache to store larger embedding tables and interact with the GPU embedding cache directly. The local RocksDB serves as a query engine to back up the complete embedding table on the local SSDs in order to assist the Redis cluster to perform missing embedding keys look up. For a detailed documentation of hugectr hierarchical parameter server, refer to [Hierarchical Parameter Server](https://nvidia-merlin.github.io/HugeCTR/main/hierarchical_parameter_server/index.html) in the HugeCTR documentation.
  
 
 ## Getting Started 


### PR DESCRIPTION
The link was broken and pointed out to me by Wenwen.  If my choice of URL isn't the one you want, PLMK.